### PR TITLE
Add an option to set custom template delimiters

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -1,4 +1,6 @@
 module.exports = (grunt) ->
+  grunt.template.addDelimiters('custom', '{%', '%}')
+
   grunt.initConfig
     pkg: grunt.file.readJSON 'package.json'
 
@@ -29,11 +31,18 @@ module.exports = (grunt) ->
 
     i18n:
       hello_world:
-        src: ['test/fixtures/*.tpl.html']
+        src: ['test/fixtures/test.tpl.html']
         options:
           locales: 'test/locales/*'
           output: 'tmp'
           base: 'test/fixtures'
+      hello_world_custom_delimiters:
+        src: ['test/fixtures/test-custom-delimiters.tpl.html']
+        options:
+          locales: 'test/locales/*'
+          output: 'tmp'
+          base: 'test/fixtures'
+          delimiters: 'custom'
 
     nodeunit:
       tests: ['test/*_test.coffee']

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ Type: String
 
 Base folder for HTML templates which should not be preserved while translating. Please check the tests if you don't get it ;)
 
+#### delimiters
+Type: String
+
+Custom delimiters name to be used instead of the default `<% %>`. See the [grunt.template documentation](http://gruntjs.com/api/grunt.template) for more details.
+
 ## Release History
 * 2013-10-23   v0.3.0   Fix for separator in output path. Add logging messages.
 * 2013-10-22   v0.2.0   Might be useful for others

--- a/src/i18n.coffee
+++ b/src/i18n.coffee
@@ -17,7 +17,9 @@ module.exports = (grunt) ->
   translateTemplates = (templatePath, localePath, options) ->
     template = grunt.file.read templatePath
     locale = grunt.file.readJSON localePath
-    localizedTemplate = grunt.template.process template, {data: locale}
+    templateOptions = {data: locale}
+    templateOptions.delimiters = options.delimiters if options.delimiters
+    localizedTemplate = grunt.template.process template, templateOptions
     outputFolder = path.basename localePath, path.extname localePath
     output = generateOutputPath outputFolder, templatePath, options
     grunt.verbose.writeln "Translating '#{templatePath}' with locale '#{localePath}' to '#{output}'"

--- a/tasks/i18n.js
+++ b/tasks/i18n.js
@@ -30,12 +30,16 @@ module.exports = function(grunt) {
     return _results;
   });
   translateTemplates = function(templatePath, localePath, options) {
-    var locale, localizedTemplate, output, outputFolder, template;
+    var locale, localizedTemplate, output, outputFolder, template, templateOptions;
     template = grunt.file.read(templatePath);
     locale = grunt.file.readJSON(localePath);
-    localizedTemplate = grunt.template.process(template, {
+    templateOptions = {
       data: locale
-    });
+    };
+    if (options.delimiters) {
+      templateOptions.delimiters = options.delimiters;
+    }
+    localizedTemplate = grunt.template.process(template, templateOptions);
     outputFolder = path.basename(localePath, path.extname(localePath));
     output = generateOutputPath(outputFolder, templatePath, options);
     grunt.verbose.writeln("Translating '" + templatePath + "' with locale '" + localePath + "' to '" + output + "'");

--- a/test/fixtures/test-custom-delimiters.tpl.html
+++ b/test/fixtures/test-custom-delimiters.tpl.html
@@ -1,0 +1,4 @@
+<body>
+    <span>{%= message %}</span>
+    <span>{%= nested.msg %}</span>
+</body>

--- a/test/i18n_test.coffee
+++ b/test/i18n_test.coffee
@@ -2,7 +2,7 @@ grunt = require 'grunt'
 
 exports.i18n =
   happyPath: (test) ->
-    test.expect 2
+    test.expect 4
 
     expected = grunt.file.read 'test/expected/en_US/test.tpl.html'
     actual = grunt.file.read 'tmp/en_US/test.tpl.html'
@@ -11,5 +11,13 @@ exports.i18n =
     expected = grunt.file.read 'test/expected/pl_PL/test.tpl.html'
     actual = grunt.file.read 'tmp/pl_PL/test.tpl.html'
     test.equal expected, actual, 'should translate a template to polish'
+
+    expected = grunt.file.read 'test/expected/en_US/test.tpl.html'
+    actual = grunt.file.read 'tmp/en_US/test-custom-delimiters.tpl.html'
+    test.equal expected, actual, 'should translate a template with custom delimiters to english'
+
+    expected = grunt.file.read 'test/expected/pl_PL/test.tpl.html'
+    actual = grunt.file.read 'tmp/pl_PL/test-custom-delimiters.tpl.html'
+    test.equal expected, actual, 'should translate a template with custom delimiters to polish'
 
     test.done()


### PR DESCRIPTION
- Added a new fixture template with custom delimiters (`{% %}`).
- Added a new Grunt i18n target with a the same custom delimiter (named `custom`).
- Tested
- Documented
