### PR TITLE
Support reading translations from YAML files

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -37,8 +37,12 @@ module.exports = (grunt) ->
         src: ['test/fixtures/test-custom-delimiters.tpl.html']
         options:
           delimiters: 'custom'
+      with_yaml:
+        src: ['test/fixtures/test-yaml.tpl.html']
+        options:
+          locales: 'test/locales/*.yaml'
       options:
-        locales: 'test/locales/*'
+        locales: 'test/locales/*.json'
         output: 'tmp'
         base: 'test/fixtures'
 

--- a/src/i18n.coffee
+++ b/src/i18n.coffee
@@ -22,7 +22,10 @@ module.exports = (grunt) ->
 
   translateTemplate = (templatePath, localePath, options) ->
     template = grunt.file.read templatePath
-    locale = grunt.file.readJSON localePath
+    if /(\.yaml|\.yml)$/.test( localePath ) 
+      locale = grunt.file.readYAML localePath
+    else
+      locale = grunt.file.readJSON localePath
     templateOptions = data: locale
     templateOptions.delimiters = options.delimiters if options.delimiters
     grunt.template.process template, templateOptions

--- a/tasks/i18n.js
+++ b/tasks/i18n.js
@@ -39,7 +39,11 @@ module.exports = function(grunt) {
   translateTemplate = function(templatePath, localePath, options) {
     var locale, template, templateOptions;
     template = grunt.file.read(templatePath);
-    locale = grunt.file.readJSON(localePath);
+    if (/(\.yaml|\.yml)$/.test(localePath)) {
+      locale = grunt.file.readYAML(localePath);
+    } else {
+      locale = grunt.file.readJSON(localePath);
+    }
     templateOptions = {
       data: locale
     };

--- a/test/fixtures/test-yaml.tpl.html
+++ b/test/fixtures/test-yaml.tpl.html
@@ -1,0 +1,4 @@
+<body>
+    <span><%= message %></span>
+    <span><%= nested.msg %></span>
+</body>

--- a/test/i18n_test.coffee
+++ b/test/i18n_test.coffee
@@ -26,3 +26,16 @@ exports.i18n =
     test.equal expected, actual, 'should translate a template with custom delimiters to polish'
 
     test.done()
+
+  should_translate_regular_grunt_templates_with_yaml_source: (test) ->
+    test.expect 2
+
+    expected = grunt.file.read 'test/expected/en_US/test.tpl.html'
+    actual = grunt.file.read 'tmp/en_US/test-yaml.tpl.html'
+    test.equal expected, actual, 'should translate a template to english (with YAML source)'
+
+    expected = grunt.file.read 'test/expected/pl_PL/test.tpl.html'
+    actual = grunt.file.read 'tmp/pl_PL/test-yaml.tpl.html'
+    test.equal expected, actual, 'should translate a template to polish (with YAML source)'
+
+    test.done()

--- a/test/locales/en_US.yaml
+++ b/test/locales/en_US.yaml
@@ -1,0 +1,3 @@
+message: Hello world!
+nested: 
+  msg: and hello to you

--- a/test/locales/pl_PL.yaml
+++ b/test/locales/pl_PL.yaml
@@ -1,0 +1,3 @@
+message: Witaj świecie!
+nested:
+  msg: i Tobie witaj


### PR DESCRIPTION
Translations are loaded in JSON of YAML format, depending on the file extensions.
