### PR TITLE
Support translations from Transifex

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -47,6 +47,12 @@ module.exports = (grunt) ->
         options:
           locales: 'test/locales/*.yaml'
           output: 'tmp/yaml'
+      with_transifex:
+        src: ['test/fixtures/test.tpl.html']
+        options:
+          locales: 'test/locales-transifex/*.yaml'
+          output: 'tmp/transifex'
+          transifex: true
       options:
         base: 'test/fixtures'
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,26 @@ Type: String
 
 Custom delimiters name to be used instead of the default `<% %>`. See the [grunt.template documentation](http://gruntjs.com/api/grunt.template) for more details.
 
+#### transifex
+Type: Bool
+
+Locales from Transifex have all their translations below one root property, the name of the translation. Setting this to true compensates for this, so you can use Transifex with your project. For example,
+
+```yaml
+en_US:
+  message: Hello world!
+  nested:
+    msg: and hello to you
+```
+
+Becomes
+
+```yaml
+message: Hello world!
+nested:
+  msg: and hello to you
+```
+
 ## Release History
 * 2013-12-06   v0.5.0   Can read locals in yaml format.
 * 2013-11-29   v0.4.0   Custom delimiters and localization file existence checks

--- a/src/i18n.coffee
+++ b/src/i18n.coffee
@@ -22,10 +22,17 @@ module.exports = (grunt) ->
 
   translateTemplate = (templatePath, localePath, options) ->
     template = grunt.file.read templatePath
-    if /(\.yaml|\.yml)$/.test( localePath ) 
+    if /(\.yaml|\.yml)$/.test( localePath )
       locale = grunt.file.readYAML localePath
     else
       locale = grunt.file.readJSON localePath
+
+    # locales from Transifex have one property to name the particular locale, with the
+    # translations all below that. E.G. { "en": {"message": "Hello, world!"} }
+    if options.transifex
+      keys = Object.keys locale
+      if keys.length is 1 and typeof locale[keys[0]] is 'object' then locale = locale[keys[0]]
+
     templateOptions = data: locale
     templateOptions.delimiters = options.delimiters if options.delimiters
     grunt.template.process template, templateOptions

--- a/tasks/i18n.js
+++ b/tasks/i18n.js
@@ -37,12 +37,16 @@ module.exports = function(grunt) {
     return _results;
   });
   translateTemplate = function(templatePath, localePath, options) {
-    var locale, template, templateOptions;
+    var keys, locale, template, templateOptions;
     template = grunt.file.read(templatePath);
     if (/(\.yaml|\.yml)$/.test(localePath)) {
       locale = grunt.file.readYAML(localePath);
     } else {
       locale = grunt.file.readJSON(localePath);
+    }
+    keys = Object.keys(locale);
+    if (keys.length === 1 && typeof locale[keys[0]] === 'object') {
+      locale = locale[keys[0]];
     }
     templateOptions = {
       data: locale

--- a/test/i18n_test.coffee
+++ b/test/i18n_test.coffee
@@ -39,3 +39,16 @@ exports.i18n =
     test.equal expected, actual, 'should translate a template to polish (with YAML locale)'
 
     test.done()
+
+  should_translate_regular_grunt_templates_with_transifex_locale: (test) ->
+    test.expect 2
+
+    expected = grunt.file.read 'test/expected/en_US/test.tpl.html'
+    actual = grunt.file.read 'tmp/transifex/en_US/test.tpl.html'
+    test.equal expected, actual, 'should translate a template to English with locale from Transifex'
+
+    expected = grunt.file.read 'test/expected/pl_PL/test.tpl.html'
+    actual = grunt.file.read 'tmp/transifex/pl_PL/test.tpl.html'
+    test.equal expected, actual, 'should translate a template to Polish with locale from Transifex'
+
+    test.done()

--- a/test/locales-transifex/en_US.yaml
+++ b/test/locales-transifex/en_US.yaml
@@ -1,0 +1,4 @@
+en_US:
+  message: Hello world!
+  nested:
+    msg: and hello to you

--- a/test/locales-transifex/pl_PL.yaml
+++ b/test/locales-transifex/pl_PL.yaml
@@ -1,0 +1,4 @@
+pl_PL:
+  message: Witaj świecie!
+  nested:
+    msg: i Tobie witaj


### PR DESCRIPTION
[Transifex](https://www.transifex.com/) translations come with all the useful stuff below one root property, the name of the translation. This adds an option to fix this.

E.G.

``` yaml
en_US:
  message: Hello world!
  nested:
    msg: and hello to you
```

becomes

``` yaml
message: Hello world!
nested:
  msg: and hello to you
```
