### PR TITLE
Added the option to have the locales in the properties format

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -53,6 +53,12 @@ module.exports = (grunt) ->
           locales: 'test/locales-transifex/*.yaml'
           output: 'tmp/transifex'
           format: 'transifex'
+      with_messages:
+        src: ['test/fixtures/test.tpl.html']
+        options:
+          locales: 'test/locales/messages.*'
+          output: 'tmp/messages'
+          format: 'messages'
       options:
         base: 'test/fixtures'
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "peerDependencies": {
         "grunt": "~0.4.0"
     },
+    "dependencies": {
+      "properties-reader": "0.0.6"
+    },
     "keywords": [
         "gruntplugin"
     ]

--- a/test/i18n_test.coffee
+++ b/test/i18n_test.coffee
@@ -52,3 +52,16 @@ exports.i18n =
     test.equal expected, actual, 'should translate a template to Polish with locale from Transifex'
 
     test.done()
+
+  should_translate_regular_grunt_templates_with_messages_locale: (test) ->
+    test.expect 2
+
+    expected = grunt.file.read 'test/expected/en_US/test.tpl.html'
+    actual = grunt.file.read 'tmp/messages/en_US/test.tpl.html'
+    test.equal expected, actual, 'should translate a template to English with locale from Messages'
+
+    expected = grunt.file.read 'test/expected/pl_PL/test.tpl.html'
+    actual = grunt.file.read 'tmp/messages/pl_PL/test.tpl.html'
+    test.equal expected, actual, 'should translate a template to Polish with locale from Messages'
+
+    test.done()

--- a/test/locales/messages
+++ b/test/locales/messages
@@ -1,0 +1,1 @@
+nested.msg=and hello to you

--- a/test/locales/messages.en_US
+++ b/test/locales/messages.en_US
@@ -1,0 +1,1 @@
+message=Hello world!

--- a/test/locales/messages.pl_PL
+++ b/test/locales/messages.pl_PL
@@ -1,0 +1,2 @@
+message=Witaj świecie!
+nested.msg=i Tobie witaj


### PR DESCRIPTION
Our project uses the play framework and the localized texts are stored in the java properties format.

The file `messages` contains the default texts, the files `messages.pl_PL` would contain the messages translated to Polish, etc.

I have added the option to use such locales, tests included.
